### PR TITLE
Add gitbook yaml for redirects

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,11 @@
+root: ./
+
+​structure:
+  readme: README.md
+  summary: SUMMARY.md​
+
+redirects:
+  citycoins-core-protocol/registration-and-activation: core-protocol/registration-and-activation.md
+  citycoins-core-protocol/mining-citycoins: core-protocol/mining-citycoins.md
+  citycoins-core-protocol/stacking-citycoins: core-protocol/stacking-citycoins.md
+  citycoins-core-protocol/issuance-schedule: core-protocol/token-configuration.md

--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -5,7 +5,7 @@ root: ./
   summary: SUMMARY.md​
 
 redirects:
-  citycoins-core-protocol/registration-and-activation: core-protocol/registration-and-activation.md
-  citycoins-core-protocol/mining-citycoins: core-protocol/mining-citycoins.md
-  citycoins-core-protocol/stacking-citycoins: core-protocol/stacking-citycoins.md
-  citycoins-core-protocol/issuance-schedule: core-protocol/token-configuration.md
+  citycoins-core-protocol/registration-and-activation: ./core-protocol/registration-and-activation.md
+  citycoins-core-protocol/mining-citycoins: ./core-protocol/mining-citycoins.md
+  citycoins-core-protocol/stacking-citycoins: ./core-protocol/stacking-citycoins.md
+  citycoins-core-protocol/issuance-schedule: ./core-protocol/token-configuration.md

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Welcome, we're glad you found us! CityCoins are powered by [Stacks](https://stac
 
 CityCoins have four main features: **Activation**, **Mining**, **Stacking,** and **Programming.**
 
-* ****[**Activation**](core-protocol/registration-and-activation.md)**:** CityCoins only exist through mining, which does not begin until 20 independent wallets signal activation after the contract is deployed. No ICO, no pre-sale, no pre-mine.
-* ****[**Mining**](core-protocol/mining-citycoins.md)**:** Anyone can mine CityCoins by submitting STX into a CityCoins smart contract on the Stacks blockchain. 30% of the STX that miners forward is sent directly to a reserved wallet for the city.
-* ****[**Stacking**](core-protocol/stacking-citycoins.md)**:** Anyone can Stack CityCoins by locking them in a CityCoins smart contract for selected reward cycles, and receive a portion of the remaining 70% of the STX sent by miners.
-* [**Programming**](developer-resources/general.md): using [Clarity](https://clarity-lang.org), the language that powers smart contracts on Stacks, CityCoins open up endless possibilities for utility, including new opportunities for developers, entrepreneurs, residents, and more.
+- [**Activation:**](core-protocol/registration-and-activation.md) CityCoins only exist through mining, which does not begin until 20 independent wallets signal activation after the contract is deployed. No ICO, no pre-sale, no pre-mine.
+- [**Mining:**](core-protocol/mining-citycoins.md) Anyone can mine CityCoins by submitting STX into a CityCoins smart contract on the Stacks blockchain. 30% of the STX that miners forward is sent directly to a reserved wallet for the city.
+- [**Stacking:**](core-protocol/stacking-citycoins.md) Anyone can Stack CityCoins by locking them in a CityCoins smart contract for selected reward cycles, and receive a portion of the remaining 70% of the STX sent by miners.
+- [**Programming:**](developer-resources/general.md) using [Clarity](https://clarity-lang.org), the language that powers smart contracts on Stacks, CityCoins open up endless possibilities for utility, including new opportunities for developers, entrepreneurs, residents, and more.
 
 Please use the navigation on the left to learn more, and if you haven't already, [come join our Discord server!](https://discord.gg/citycoins)

--- a/about-citycoins/how-do-i-get-started.md
+++ b/about-citycoins/how-do-i-get-started.md
@@ -10,17 +10,17 @@ CityCoins follow the [SIP-010 fungible token standard](https://github.com/stacks
 
 The currently supported wallets for CityCoins are listed below.
 
-|                                                       |                                                               |                                                     |
-| ----------------------------------------------------- | :-----------------------------------------------------------: | :-------------------------------------------------: |
-| **Features**                                          | ****[**Hiro Wallet**](https://hiro.so/wallet/install-web)**** | ****[**Xverse Wallet**](https://www.xverse.app)**** |
-| <p>Desktop Support</p><p><em>(Win/Mac/Linux)</em></p> |                               ⚠                               |                                                     |
-| <p>Web Support</p><p><em>(Chrome/Firefox)</em></p>    |                               ✅                               |                                                     |
-| <p>Mobile Support</p><p><em>(Android/iPhone)</em></p> |                                                               |                          ✅                          |
-| Activation                                            |                               ✅                               |                                                     |
-| Mining                                                |                               ✅                               |                                                     |
-| Stacking                                              |                               ✅                               |                                                     |
-| Send                                                  |                               ✅                               |                          ✅                          |
-| Receive                                               |                               ✅                               |                          ✅                          |
+|                                                       |                                                       |                                             |
+| ----------------------------------------------------- | :---------------------------------------------------: | :-----------------------------------------: |
+| **Features**                                          | [**Hiro Wallet**](https://hiro.so/wallet/install-web) | [**Xverse Wallet**](https://www.xverse.app) |
+| <p>Desktop Support</p><p><em>(Win/Mac/Linux)</em></p> |                           ⚠                           |                                             |
+| <p>Web Support</p><p><em>(Chrome/Firefox)</em></p>    |                          ✅                           |                                             |
+| <p>Mobile Support</p><p><em>(Android/iPhone)</em></p> |                                                       |                     ✅                      |
+| Activation                                            |                          ✅                           |                                             |
+| Mining                                                |                          ✅                           |                                             |
+| Stacking                                              |                          ✅                           |                                             |
+| Send                                                  |                          ✅                           |                     ✅                      |
+| Receive                                               |                          ✅                           |                     ✅                      |
 
 {% hint style="warning" %}
 The desktop version of the Hiro Wallet does not support displaying, sending, or receiving CityCoins at this time. [Kindly let them know we want it!](https://github.com/hirosystems/stacks-wallet/issues/897)
@@ -39,4 +39,3 @@ All CityCoins are fungible tokens on Stacks, meaning they are stored as part of 
 {% hint style="info" %}
 When sending or receiving CityCoins, use the Stacks address of the sender and recipient.
 {% endhint %}
-


### PR DESCRIPTION
This should close the loop on some dead links in older publications / references.

It also fixes some weird markdown formatting that likely came through from the editor. ([xkcd ref](https://xkcd.com/2109/))