### PR TITLE
Add two missing redirects from UI

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -7,5 +7,7 @@ root: ./
 redirects:
   citycoins-core-protocol/registration-and-activation: ./core-protocol/registration-and-activation.md
   citycoins-core-protocol/mining-citycoins: ./core-protocol/mining-citycoins.md
+  citycoins-core-protocol/claiming-mining-rewards: ./core-protocol/mining-citycoins.md
   citycoins-core-protocol/stacking-citycoins: ./core-protocol/stacking-citycoins.md
+  citycoins-core-protocol/claiming-stacking-rewards: ./core-protocol/stacking-citycoins.md
   citycoins-core-protocol/issuance-schedule: ./core-protocol/token-configuration.md


### PR DESCRIPTION
The UI points to these old pages:

https://docs.citycoins.co/citycoins-core-protocol/claiming-mining-rewards
https://docs.citycoins.co/citycoins-core-protocol/claiming-stacking-rewards

This update redirects them to the main mining/stacking pages in the docs instead.